### PR TITLE
fix: ensure hostname is dashified in topic name

### DIFF
--- a/lib/ntfy.js
+++ b/lib/ntfy.js
@@ -37,7 +37,7 @@ ntfy.regenerateTopic = async (uid) => {
 		utils.generateUUID().slice(0, 8),
 		user.getUserField(uid, 'userslug'),
 	]);
-	const name = `${slugify(hostname)}-${userslug}-${uuid}`;
+	const name = `${slugify(hostname).replaceAll('.', '-')}-${userslug}-${uuid}`;
 	await user.setUserField(uid, 'ntfyTopic', name);
 
 	return name;


### PR DESCRIPTION
While setting up this plugin on my instance, I've noticed that the topic name it generates for subscribing to notifications wouldn't work with ntfy.sh, being impossible to confirm in the app (the button would be disabled) and returning a code 40401, http 404, error "page not found" if accessed via `https://ntfy.sh/<name>`.

After some attempts at manually writing topic names inside the app, I've noticed that the problem is how the service rejects topic names containing dots (`.`), and indeed the plugin was generating names that did contain them, inside the forum's hostname.

Apparently, the `slugify` function called here doesn't remove or dashify dots. Since it's used globally in NodeBB, and I don't know if that is the desired behaviour or not, changing it would cause a lot of problems, so to tackle this issue it's better to just do a simple character replacement directly in this plugin's code.

I've confirmed that, with this change, on my instance the plugin generates topic names that are now fully working with ntfy.sh. Existing configurations are unaffected, since this fix only handles how topic names are (re)generated.